### PR TITLE
Fix google maps on the contact us page

### DIFF
--- a/contact-us.html
+++ b/contact-us.html
@@ -44,7 +44,58 @@
 	<script src="media/system/js/mootools-core03f5.js?6a52780d8ec1e60a5f6ad7554b3ecd36" type="text/javascript"></script>
 	<script src="media/system/js/core03f5.js?6a52780d8ec1e60a5f6ad7554b3ecd36" type="text/javascript"></script>
 	<script src="plugins/system/jabuilder/assets/js/jabuilder.js" type="text/javascript"></script>
-	<script src="http://maps.google.com/maps/api/js?language=en-GB&amp;key=AIzaSyDIE6SiLMRzA-_zUPis9FVkazPF9NRO5po" type="text/javascript"></script>
+<script type="text/javascript">
+var config = {
+    mapType: 'roadmap',
+    width: 'auto',
+    height: '350',
+    cavas_id: "cavas_id173",
+    zoom: 15,
+    zoomControl: true,
+    scaleControl: true,
+    panControl: true,
+    mapTypeControl: true,
+    streetViewControl: true,
+    overviewMapControl: true,
+    draggable: true,
+    disableDoubleClickZoom: false,
+    scrollwheel: true,
+    weather: 0,
+    temperatureUnit: 'f',
+    replaceMarkerIcon: 1,
+    displayWeatherInfo: 1,
+    owm_api: "",
+    mapCenterType: "address",
+    mapCenterAddress: "Landsbergerstr. 302 Munich GERMANY",
+    mapCenterCoordinate: "40.7143528, -74.0059731",
+    enableStyle: "0",
+    styleTitle: "BT Map",
+    createNewOrDefault: "createNew",
+    enableCustomInfoBox: "0",
+    boxPosition: "-150,-155",
+    closeBoxMargin: "-9px",
+    closeBoxImage: "",
+    url: "http://www.otomobilgi.com/deepnetwork/"
+};
+var boxStyles = {
+    "background": "#ffffff",
+    "opacity": " 0.85",
+    "width": " 280px",
+    "height": "100px",
+    "border": " 1px solid grey",
+    "borderRadius": "3px",
+    "padding": " 10px",
+    "boxShadow": "30px 10px 10px 1px grey"
+};
+var markersCode = "W3sibWFya2VyVGl0bGUiOiJEZWVwIE5ldHdvcmsgR21iSCIsIm1hcmtlclR5cGUiOiJhZGRyZXNzIiwibWFya2VyVmFsdWUiOiJMYW5kc2JlcmdlcnN0ci4gMzAyIE11bmljaCBHRVJNQU5ZIiwibWFya2VySWNvbiI6IiIsIm1hcmtlclNob3dJbmZvV2luZG93IjoiMSIsIm1hcmtlckluZm9XaW5kb3ciOiIifV0=";
+var stylesCode = "W10=";
+function initMap() {
+    jQuery(document).ready(function () {
+        initializeMap(config, markersCode, stylesCode, boxStyles);
+    });
+}
+    </script>
+	<script async defer src="http://maps.google.com/maps/api/js?language=en-GB&amp;key=AIzaSyDIE6SiLMRzA-_zUPis9FVkazPF9NRO5po&callback=initMap" type="text/javascript"></script>
 	<script src="modules/mod_bt_googlemaps/tmpl/js/btbase64.min.js" type="text/javascript"></script>
 	<script src="modules/mod_bt_googlemaps/tmpl/js/default.js" type="text/javascript"></script>
 	<!--[if lt IE 9]><script src="/deepnetwork/media/system/js/html5fallback.js?6a52780d8ec1e60a5f6ad7554b3ecd36" type="text/javascript"></script><![endif]-->
@@ -347,20 +398,9 @@ jQuery(function($){ initTooltips(); $("body").on("subform-row-add", initTooltips
 </div> 
 
 
-		<div class="section-wrap t3-content-bottom ">
-    <div id="cavas_id173" class="bt-googlemaps"></div>
-<script type="text/javascript">var config = {mapType				:'roadmap',width					:'auto',height					:'350',cavas_id				:"cavas_id173", zoom					:15,zoomControl			:true,scaleControl			:true,panControl				:true,mapTypeControl			:true,streetViewControl		:true,overviewMapControl		:true,draggable		:true,disableDoubleClickZoom		:false,scrollwheel		:true,weather				:0,temperatureUnit		:'f',replaceMarkerIcon		:1,displayWeatherInfo					:1,owm_api: "", mapCenterType			:"address",mapCenterAddress		:"Landsbergerstr. 302 Munich GERMANY",mapCenterCoordinate	:"40.7143528, -74.0059731",enableStyle			:"0",styleTitle				:"BT Map",createNewOrDefault		:"createNew",enableCustomInfoBox	:"0",boxPosition			:"-150,-155",closeBoxMargin			:"-9px",closeBoxImage			:"",url:"http://www.otomobilgi.com/deepnetwork/"};var boxStyles = {"background":"#ffffff","opacity":" 0.85","width":" 280px","height":"100px","border":" 1px solid grey","borderRadius":"3px","padding":" 10px","boxShadow":"30px 10px 10px 1px grey"};var markersCode ="W3sibWFya2VyVGl0bGUiOiJEZWVwIE5ldHdvcmsgR21iSCIsIm1hcmtlclR5cGUiOiJhZGRyZXNzIiwibWFya2VyVmFsdWUiOiJMYW5kc2JlcmdlcnN0ci4gMzAyIE11bmljaCBHRVJNQU5ZIiwibWFya2VySWNvbiI6IiIsIm1hcmtlclNob3dJbmZvV2luZG93IjoiMSIsIm1hcmtlckluZm9XaW5kb3ciOiIifV0="; var stylesCode ="W10="; initializeMap(config, markersCode, stylesCode, boxStyles);</script>
-
+    <div class="section-wrap t3-content-bottom ">
+        <div id="cavas_id173" class="bt-googlemaps"></div>
 	</div>
-
-	
-	
-
-
-	
-
-
-
 	
 <!-- BACK TOP TOP BUTTON -->
 <div id="back-to-top" data-spy="affix" data-offset-top="200" class="back-to-top hidden-xs hidden-sm affix-top">


### PR DESCRIPTION
Fixes #21 
* Asynx defer google maps scripts
* Load google maps via callback `initMap`
* Callback only executes when the doc is loaded and the placeholder is
in place