### PR TITLE
Fix e-mail & phone number icons wrapping

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,15 +21,14 @@
                         <ul class="address-list">
                             <li>
                                 <label>
-                                    <i class="fas fa-envelope"></i>
+                                    <a href="mailto:info@deepnetwork.com"><i class="fas fa-envelope"></i> info@deepnetwork.com</a>
                                 </label>
-                                <a href="mailto:info@deepnetwork.com">info@deepnetwork.com</a>
                             </li>
                             <li>
                                 <label>
-                                    <i class="fas fa-phone"></i>
+                                    <a href="tel:+49 (0) 89 2316 6638"><i class="fas fa-phone"></i> +49 (0) 89 2316 6638</a>
                                 </label>
-                                <a href="tel:+49 (0) 89 2316 6638">+49 (0) 89 2316 6638</a><br /><br /></li>
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Before:
<img width="370" alt="image" src="https://user-images.githubusercontent.com/5593342/69880656-d1c0f900-12ca-11ea-9355-58c9c5c0f077.png">

After:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/5593342/69880651-ccfc4500-12ca-11ea-9200-dcf259226167.png">
